### PR TITLE
Remove recipe for adding `classNames` to a view.

### DIFF
--- a/adding_css_classes_to_your_views.mdown
+++ b/adding_css_classes_to_your_views.mdown
@@ -1,9 +1,0 @@
-# Adding CSS Classes to Your Views
-
-## Problem
-You want to add CSS class names to your Ember Views.
-
-## Solution
-Set additional class names with the `classNames` property of subclassed views or supply additional class names with the `classes` options when using the `{{view}}` helper in a template.
-
-## Discussion


### PR DESCRIPTION
This is just... HTML now!